### PR TITLE
Enforce admin role on AdminController endpoints

### DIFF
--- a/music-app/src/main/java/com/musicspring/app/music_app/controller/AdminController.java
+++ b/music-app/src/main/java/com/musicspring/app/music_app/controller/AdminController.java
@@ -14,11 +14,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/admin")
 @Tag(name = "Admin", description = "Administrative operations")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminController {
     private final ReviewService reviewService;
 

--- a/music-app/src/main/java/com/musicspring/app/music_app/security/config/SecurityConfig.java
+++ b/music-app/src/main/java/com/musicspring/app/music_app/security/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import com.musicspring.app.music_app.security.oauth2.handlers.OAuth2AuthenticationFailureHandler;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -22,6 +23,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -51,7 +53,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(auth -> auth
-                        .requestMatchers("api/v1/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/v1/stats/admin/**").hasRole("ADMIN")
 
                         .requestMatchers("/api/v1/auth/**",


### PR DESCRIPTION
Added @PreAuthorize("hasRole('ADMIN')") to AdminController and enabled method security with @EnableMethodSecurity in SecurityConfig. Also fixed admin endpoint matcher to include leading slash for correct path matching.