### PR TITLE
Enable user activation on signup and remove email verification

### DIFF
--- a/music-app/src/main/java/com/musicspring/app/music_app/security/service/AuthService.java
+++ b/music-app/src/main/java/com/musicspring/app/music_app/security/service/AuthService.java
@@ -175,7 +175,7 @@ public class AuthService {
             throw new IllegalArgumentException("Username already taken: " + signupRequest.getUsername());
 
         UserEntity user = userMapper.toUserEntity(signupRequest);
-        user.setActive(false);
+        user.setActive(true);
         user = userRepository.save(user);
 
         CredentialEntity credential = credentialMapper.toCredentialEntity(signupRequest, user);
@@ -191,15 +191,15 @@ public class AuthService {
         credential = credentialsRepository.save(credential);
         user.setCredential(credential);
 
-        try {
-            emailVerificatorService.sendVerificationEmail(user,EmailType.REGISTRATION);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Error sending email: " + e.getMessage());
-        }
+//        try {
+//            emailVerificatorService.sendVerificationEmail(user,EmailType.REGISTRATION);
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//            throw new RuntimeException("Error sending email: " + e.getMessage());
+//        }
 
         return ResponseEntity.ok(Map.of(
-                "message", "Verification email sent to: " + credential.getEmail()
+                "message", "User registered successfully. Please login."
         ));
     }
 


### PR DESCRIPTION
Users are now set as active upon registration instead of inactive. The email verification step has been commented out, and the response message has been updated to indicate successful registration without email verification.